### PR TITLE
switch from simple git flow to more professionell flow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @lane4digital

--- a/support/README.de.md
+++ b/support/README.de.md
@@ -1,0 +1,66 @@
+# Erklärung des Shellskript-Patterns
+
+Das angegebene Pattern im Shellskript lautet:
+```
+pattern="^(feature|fix|hotfix)\/\d{6,7}_[a-zA-Z0-9_-]+|:[0-9a-f]{7,40}$"
+```
+
+Dieser reguläre Ausdruck definiert folgende gültige und ungültige Formate:
+
+---
+
+## **Gültige Formate** (Erfüllen das Pattern)
+1. **Feature-, Fix- oder Hotfix-Branches**:
+   - **Format**: `feature/123456_something` oder `fix/1234567_something_else`
+   - **Beschreibung**:
+      - Beginnt mit `feature/`, `fix/` oder `hotfix/`.
+      - Darauf folgt eine Ziffernfolge aus 6 oder 7 Ziffern (`\d{6,7}`).
+      - Danach ein Unterstrich (`_`) und mindestens ein Zeichen aus `[a-zA-Z0-9_-]`.
+
+   **Beispiele**:
+   - `feature/123456_example-feature`
+   - `fix/1234567_bug-fix`
+   - `hotfix/987654_update`
+
+2. **Git-Commit-Hashes**:
+   - **Format**: `:abc1234`, `:abcdef1234567890` oder `:123456789abcdef...`
+   - **Beschreibung**:
+      - Beginnt mit einem Doppelpunkt (`:`).
+      - Darauf folgt eine Hexadezimalfolge von 7 bis 40 Zeichen (`[0-9a-f]{7,40}`).
+
+   **Beispiele**:
+   - `:abc1234`
+   - `:abcdef1234567890`
+   - `:123456789abcdefabcdefabcdefabcdefabcdef`
+
+---
+
+## **Ungültige Formate** (Erfüllen das Pattern nicht)
+1. **Ungültige Branchnamen**:
+   - Beginnt nicht mit `feature/`, `fix/` oder `hotfix/`.
+   - Enthält weniger als 6 Ziffern.
+   - Fehlt ein `_` nach den Ziffern.
+
+   **Beispiele**:
+   - `update/123456_example` (falsches Präfix)
+   - `fix/1234_example` (zu wenig Ziffern)
+   - `fix/123456example` (kein `_` zwischen Ziffern und Name)
+
+2. **Ungültige Commit-Hashes**:
+   - Fehlt das Doppelpunkt-Präfix (`:`).
+   - Hexadezimalfolgen kürzer als 7 Zeichen oder länger als 40 Zeichen.
+   - Enthält ungültige Zeichen.
+
+   **Beispiele**:
+   - `abc1234` (fehlt das `:`)
+   - `:1234` (zu kurz)
+   - `:123456789ghijklmnop` (ungültige Zeichen)
+
+---
+
+## **Zusammenfassung**
+Das Pattern funktioniert für:
+- Branchnamen mit festgelegtem Präfix und strukturierter Bezeichnung.
+- Git-Commit-Hashes im Format `:[0-9a-f]{7,40}`.
+
+Falls du unsicher bist, ob ein bestimmter Input gültig ist, kannst du ihn testen oder um Hilfe bitten!

--- a/support/README.md
+++ b/support/README.md
@@ -1,0 +1,66 @@
+# Explanation of the Shell Script Pattern
+
+The provided pattern in the shell script is as follows:
+```
+pattern="^(feature|fix|hotfix)\/\d{6,7}_[a-zA-Z0-9_-]+|:[0-9a-f]{7,40}$"
+```
+
+This regex defines the following formats that are valid and invalid:
+
+---
+
+## **Valid Formats** (Match the Pattern)
+1. **Feature, Fix, or Hotfix Branch Names**:
+    - **Format**: `feature/123456_something` or `fix/1234567_something_else`
+    - **Description**:
+        - Starts with `feature/`, `fix/`, or `hotfix/`.
+        - Followed by a sequence of 6 or 7 digits (`\d{6,7}`).
+        - Followed by an underscore (`_`) and at least one character from `[a-zA-Z0-9_-]`.
+
+   **Examples**:
+    - `feature/123456_example-feature`
+    - `fix/1234567_bug-fix`
+    - `hotfix/987654_update`
+
+2. **Git Commit Hashes**:
+    - **Format**: `:abc1234`, `:abcdef1234567890`, or `:123456789abcdef...`
+    - **Description**:
+        - Starts with a colon (`:`).
+        - Followed by a hexadecimal sequence of 7 to 40 characters (`[0-9a-f]{7,40}`).
+
+   **Examples**:
+    - `:abc1234`
+    - `:abcdef1234567890`
+    - `:123456789abcdefabcdefabcdefabcdefabcdef`
+
+---
+
+## **Invalid Formats** (Do Not Match the Pattern)
+1. **Invalid Branch Names**:
+    - Does not start with `feature/`, `fix/`, or `hotfix/`.
+    - Contains fewer than 6 digits.
+    - Lacks an underscore (`_`) after the digits.
+
+   **Examples**:
+    - `update/123456_example` (wrong prefix)
+    - `fix/1234_example` (too few digits)
+    - `fix/123456example` (missing `_` between digits and name)
+
+2. **Invalid Commit Hashes**:
+    - Missing the colon prefix (`:`).
+    - Hexadecimal sequence shorter than 7 characters or longer than 40 characters.
+    - Contains invalid characters.
+
+   **Examples**:
+    - `abc1234` (missing `:`)
+    - `:1234` (too short)
+    - `:123456789ghijklmnop` (contains invalid characters)
+
+---
+
+## **Summary**
+This pattern works for:
+- Branch names with specific prefixes and structured naming.
+- Git commit hashes in the format `:[0-9a-f]{7,40}`.
+
+If you're unsure whether a specific input is valid, feel free to test it or ask for assistance!

--- a/support/pre-commit-hook.sh
+++ b/support/pre-commit-hook.sh
@@ -8,21 +8,21 @@ user="$(git config user.name)"
 gitDir="$(git rev-parse --git-dir)"
 files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.php')
 
-#branch="$(git rev-parse --abbrev-ref HEAD)"
-#commits="$(git rev-list --count HEAD ^${branch})"
-#pattern="^(feature|fix|hotfix)\/[0-9]{6,7}_[a-zA-Z0-9_-]+|:[0-9a-f]{7,40}$"
+branch="$(git rev-parse --abbrev-ref HEAD)"
+commits="$(git rev-list --count HEAD ^${branch})"
+pattern="^(feature|fix|hotfix)\/[0-9]{6,7}_[a-zA-Z0-9_-]+|:[0-9a-f]{7,40}$"
 
 if [[ -d "${gitDir}/rebase-merge" || -d "${gitDir}/rebase-apply" ]]; then
     exit 0;
 fi
 
-#if [[ $commits -eq 0 ]]; then
-#    echo "Validate branch name..."
-#    if [[ ! $branch_name =~ $pattern ]]; then
-#        echo -e "\e[1;31mCommit not valid because of branch name '${branch}' !\n\e[0m"
-#        exit 1;
-#    fi
-#fi
+if [[ $commits -eq 0 ]]; then
+    echo "Validate branch name..."
+    if [[ ! $branch_name =~ $pattern ]]; then
+        echo -e "\e[1;31mCommit not valid because of branch name '${branch}' !\n\e[0m"
+        exit 1;
+    fi
+fi
 
 echo "Committing as user ${user}"
 if [[ $user =~ [.,:'!@#$%^&*()_+'] ]]; then


### PR DESCRIPTION
* switch from simple git flow to more professionell flow
- avoid commits to main
- use branches
- commit restrictions
- branch name restrictions
- added CODEOWNERS